### PR TITLE
Pkg 4243 v12.3 initial

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,5 @@
 arm_variant_type: # [aarch64]
   - sbsa          # [aarch64]
+conda_glibc_ver:
+  - 2.17          # [not aarch64]
+  - 2.26          # [aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
 build:
   number: 1
   binary_relocation: false
-  skip: true  # [osx]
+  skip: true # [osx or (linux and s390x)]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - sysroot_{{ target_platform }} {{ conda_glibc_ver }}    # [linux]
         - patchelf <0.18.0                      # [linux]
       host:
@@ -86,7 +86,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - sysroot_{{ target_platform }} {{ conda_glibc_ver }}    # [linux]
       host:
         - cuda-version {{ cuda_version }}
@@ -125,7 +125,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
-        - arm-variant * {{ arm_variant_type }}  # [aarch64]
+        #- arm-variant * {{ arm_variant_type }}  # [aarch64]
         - sysroot_{{ target_platform }} {{ conda_glibc_ver }}    # [linux]
       host:
         - cuda-version {{ cuda_version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} 2.17    # [linux]
+        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}    # [linux]
         - patchelf <0.18.0                      # [linux]
       host:
          - cuda-version {{ cuda_version }}
@@ -87,7 +87,7 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} 2.17    # [linux]
+        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}    # [linux]
       host:
         - cuda-version {{ cuda_version }}
       run:
@@ -126,7 +126,7 @@ outputs:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
-        - sysroot_{{ target_platform }} 2.17    # [linux]
+        - sysroot_{{ target_platform }} {{ conda_glibc_ver }}    # [linux]
       host:
         - cuda-version {{ cuda_version }}
       run:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4585](https://anaconda.atlassian.net/browse/PKG-4585)

### Explanation of changes:

- Sixth package of CUDA 12.4 build, following [conda-forge's pattern](https://github.com/conda-forge/staged-recipes/issues/21382) which was developed in conjunction with Nvidia. I don't see a need to stage these then release them all at once. They won't cause a problem released one at a time.
- Please check the main branch too, this has just been forked
- Changes made to adjust feedstocks for differences between conda-forge and defaults. Please see commit messages for description of changes.


[PKG-4585]: https://anaconda.atlassian.net/browse/PKG-4585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ