### PR TITLE
cuda-nvrtc v13.1.115

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,8 +6,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -8,8 +8,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -138,12 +138,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -170,7 +170,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/cuda-nvrtc-split-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+build_parameters:
+  - "--suppress-variables"
+  #- "--skip-existing"
+  - "--error-overlinking"
+
+staging_channel_upload_target: ctk-13.1.1-build-1
+
+channels:
+  - https://staging.continuum.io/pbp/ctk-13.1.1-build-1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cuda-nvrtc" %}
-{% set version = "13.0.88" %}
-{% set cuda_version = "13.0" %}
+{% set version = "13.1.80" %}
+{% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
 {% set platform = "linux-sbsa" %}  # [aarch64]
@@ -18,9 +18,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/{{ platform }}/cuda_nvrtc-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: 00038aac08e1dba6f1933237dbfb217ac6452ae24fab970edcac808f103ca64b  # [linux64]
-  sha256: decf9977ab114ff195c8cdfce6fbc94aea4a62efdae628092cbb9fd1c31cda1a  # [aarch64]
-  sha256: 8c50a52467826167e0dbe99936140c52d62272bfc5849fe2d6587d050c8c5d29  # [win]
+  sha256: e4250fe1b8d02fa324ecae50777ba6d23a74712a2a23eb6233fced170de876af  # [linux64]
+  sha256: 35d93449ab34f758c0de08e50d1513a4de214702e4bb47969a12ca0ffc5e23a5  # [aarch64]
+  sha256: 7cafb794c68c11b3cd7d64a1d701638eeda227e031233e3d1e70f4e00f3b51c5  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cuda-nvrtc" %}
-{% set version = "13.1.80" %}
+{% set version = "13.1.115" %}
 {% set cuda_version = "13.1" %}
 {% set platform = "linux-x86_64" %}  # [linux64]
 {% set platform = "linux-ppc64le" %}  # [ppc64le]
@@ -18,9 +18,9 @@ package:
 
 source:
   url: https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvrtc/{{ platform }}/cuda_nvrtc-{{ platform }}-{{ version }}-archive.{{ extension }}
-  sha256: e4250fe1b8d02fa324ecae50777ba6d23a74712a2a23eb6233fced170de876af  # [linux64]
-  sha256: 35d93449ab34f758c0de08e50d1513a4de214702e4bb47969a12ca0ffc5e23a5  # [aarch64]
-  sha256: 7cafb794c68c11b3cd7d64a1d701638eeda227e031233e3d1e70f4e00f3b51c5  # [win]
+  sha256: 86077f16674ccea3e621ade9678887a37aca8f7500091aee4cabb1915e0c527b  # [linux64]
+  sha256: 77ea897622931bbbe5761161454e1eab2cb82f9a8fc1386999415b71e8ff7bed  # [aarch64]
+  sha256: 4ddd5a1e34fd62bb41e78c0725edfbf5609f4ecedd7fe118eddf2148b097fc91  # [win]
 
 build:
   number: 0


### PR DESCRIPTION
cuda-nvrtc 13.1.115

**Destination channel:** defaults

### Links

- [PKG-12011](https://anaconda.atlassian.net/browse/PKG-12011) 
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- CUDA 13.1 release


[PKG-12011]: https://anaconda.atlassian.net/browse/PKG-12011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ