### PR TITLE
cuda-nvrtc v12.9.86

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!/abs.yaml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,9 @@
+# build_parameters:
+#   - "--suppress-variables"
+#   #- "--skip-existing"
+#   - "--error-overlinking"
+
+# staging_channel_upload_target: ctk-12.9-build-4
+
+# channels:
+#   - https://staging.continuum.io/pbp/ctk-12.9-build-4

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,9 +1,10 @@
+# Please see the note on "arm-variant-feedstock" cbc.yaml file regarding tegra builds
 arm_variant_type: # [aarch64]
   - sbsa          # [linux and aarch64]
-  - tegra         # [linux and aarch64]
+#  - tegra         # [linux and aarch64]
 c_stdlib_version:  # [linux]
-  - 2.17           # [linux and aarch64]
-  - 2.34           # [linux and aarch64]
+  - "2.28"          # [linux and aarch64]
+#  - 2.34            # [linux and aarch64]
 
 zip_keys:               # [linux and aarch64]
   -                     # [linux and aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,9 @@ source:
   sha256: 1aa0644fa53c8ca34cdc73db17bcc73530557bdd3f582c7bfdbd7916c8b48f65  # [win]
 
 build:
-  number: 1
+  number: 0
   binary_relocation: false
-  skip: true  # [osx or ppc64le]
+  skip: true  # [osx]
 
 requirements:
   build:
@@ -37,6 +37,12 @@ requirements:
 
 outputs:
   - name: cuda-nvrtc
+    build:
+      binary_relocation: false
+      missing_dso_whitelist:
+        # Needed due to the use of conda-build's --error-overlinking command-line argument
+        - '*libgcc_s.so*'   # [linux]
+        - '*libstdc++.so*'  # [linux]
     files:
       - lib/libnvrtc*.so.*                            # [linux]
       - targets/{{ target_name }}/lib/libnvrtc*.so.*  # [linux]
@@ -69,10 +75,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: NVRTC native runtime libraries
       description: |
         NVRTC native runtime libraries
       doc_url: https://docs.nvidia.com/cuda/nvrtc/
+      dev_url: https://docs.nvidia.com/cuda/nvrtc/
 
   - name: cuda-nvrtc-dev
     build:
@@ -116,10 +124,12 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: NVRTC native runtime libraries
       description: |
         NVRTC native runtime libraries
       doc_url: https://docs.nvidia.com/cuda/nvrtc/
+      dev_url: https://docs.nvidia.com/cuda/nvrtc/
 
   - name: cuda-nvrtc-static
     files:
@@ -148,20 +158,24 @@ outputs:
       license_file: LICENSE
       license: LicenseRef-NVIDIA-End-User-License-Agreement
       license_url: https://docs.nvidia.com/cuda/eula/index.html
+      license_family: Other
       summary: NVRTC native runtime libraries
       description: |
         NVRTC native runtime libraries
       doc_url: https://docs.nvidia.com/cuda/nvrtc/
+      dev_url: https://docs.nvidia.com/cuda/nvrtc/
 
 about:
   home: https://developer.nvidia.com/cuda-toolkit
   license_file: LICENSE
   license: LicenseRef-NVIDIA-End-User-License-Agreement
   license_url: https://docs.nvidia.com/cuda/eula/index.html
+  license_family: Other
   summary: NVRTC native runtime libraries
   description: |
     NVRTC native runtime libraries
   doc_url: https://docs.nvidia.com/cuda/nvrtc/
+  dev_url: https://docs.nvidia.com/cuda/nvrtc/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
cuda-nvrtc v12.9.86

**Destination channel:** defaults

### Links

- [PKG-12777](https://anaconda.atlassian.net/browse/PKG-12777) 
- [CUDA 12.9 release notes](https://docs.nvidia.com/cuda/archive/12.9.1/cuda-toolkit-release-notes/index.html) for list of packages, version numbers, etc.

### Explanation of changes:

- CUDA 12.9 release
- Added `abs.yaml` for possible use of staging channels in future builds


[PKG-12777]: https://anaconda.atlassian.net/browse/PKG-12777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ